### PR TITLE
Add support for docker login command, update tests and readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,29 @@ docker.command('search nginxcont').then(function (data) {
 // }
 ```
 
+* docker login
+
+```js
+docker.command('login -u myusername -p mypassword').then(function (data) {
+  console.log('data = ', data);
+  // Successful login
+ }, function (rejected) {
+ 	console.log('rejected = ', rejected);
+ 	// Failed login
+ });
+
+// data =  { command: 'docker   login -u myusername -p mypassword ',
+//          raw: 'Login Succeeded\n',
+//          login: 'Login Succeeded' }
+
+// rejected =  error: 'Error: Command failed: docker   login -u fakeUsername -p fakePassword 
+//        WARNING! Using --password via the CLI is insecure. Use --password-stdin.
+//        Error response from daemon: Get https://registry-1.docker.io/v2/: unauthorized: incorrect username or password
+//        ' stdout = '' stderr = 'WARNING! Using --password via the CLI is insecure. Use --password-stdin.
+//        Error response from daemon: Get https://registry-1.docker.io/v2/: unauthorized: incorrect username or password
+```
+
+
 ## License
 
 MIT

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -95,4 +95,43 @@ test('docker-cli-js', t => {
     });
   });
 
+  t.test('login success', t => {
+
+    let docker = new Docker();
+
+    // if this these credentials ever fail, they should be replaced with new valid ones.
+    return docker.command('login -u myusername -p mypassword').then(function(data) {
+      console.log('data = ', data);
+
+      // if login succeeds, these tests should pass
+      t.notOk(/error/.test(data));
+      t.ok(data.login);
+    }, function(data) {
+      console.log('data = ', data);
+
+      // if login is rejected, these tests should fail
+      t.notOk(/error/.test(data));
+      t.ok(data.login);
+    });
+  });
+
+  t.test('login fail', t => {
+
+    let docker = new Docker();
+
+    return docker.command('login -u fakeUsername -p fakePassword').then(function (data) {
+      console.log('data = ', data);
+
+      // if login succeeds, these tests should fail
+      t.ok(/error/.test(data));
+      t.notOk(data.login);
+    }, function (data) {
+      console.log('data = ', data);
+
+      // if login is rejected, these tests should pass
+      t.ok(/error/.test(data));
+      t.notOk(data.login);
+    });
+  });
+
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,6 +127,14 @@ const extractResult = function (result: any) {
         return resultp;
       },
     },
+    {
+      re: / login /,
+      run: function (resultp: any) {
+        resultp.login = resultp.raw.trim();
+
+        return resultp;
+      },
+    },
   ];
 
   extracterArray.forEach(function (extracter) {


### PR DESCRIPTION
Docker `login` command accepts --username and --password parameters.

The promise is resolved upon successful login.
The promise is rejected upon unsuccessful login.

Tests added for both successful and unsuccessful login.

Readme updated.