### PR TITLE
chore: update lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -134,6 +134,11 @@
           "version": "4.14.119",
           "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.119.tgz",
           "integrity": "sha512-Z3TNyBL8Vd/M9D9Ms2S3LmFq2sSMzahodD6rCS9V2N44HUMINb75jNkSuwAx7eo2ufqTdfOdtGQpNbieUjPQmw=="
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         }
       }
     },
@@ -414,9 +419,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "make-error": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "cli-table-2-json": "1.0.12",
     "dockermachine-cli-js": "3.0.4",
-    "lodash": "4.17.11",
+    "lodash": "^4.17.15",
     "nodeify-ts": "1.0.6"
   }
 }


### PR DESCRIPTION
Bumps lodash to the latest and greatest version:

Changelog from: https://github.com/lodash/lodash/wiki/Changelog

**v4.17.15**
July 17, 2019 — Diff — Docs
- Removed unintentionally published project helper scripts

**v4.17.14**
July 10, 2019 — Diff — Docs
- Reverted use of the "type" field in package.json of lodash-es

**v4.17.13**
July 9, 2019 — Diff — Docs
- Fixed missing dependency of _createRound

**v4.17.12**
July 9, 2019 — Diff — Docs

- Ensured _.ceil, _.floor, & _round handle Infinity consistently
- Ensured _.debounce clears old timers before starting new ones
- Ensured _.mergeWith always provides a stack to customizer
- Ensured additions to Object.prototype don’t break lodash initialization
- Ensured map and set clones contain custom properties of source values
- Fixed prototype pollution for _.defaultsDeep
- Fixed prototype pollution for _.template options
