### PR TITLE
Added the ability to stream 'stdout' and 'stderr' from docker command.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -208,7 +208,7 @@ export class Docker {
         //console.log('execCommand =', execCommand);
         //console.log('exec options =', execOptions);
 
-        exec(execCommand, execOptions, function(error, stdout, stderr) {
+        const childProcess = exec(execCommand, execOptions, function(error, stdout, stderr) {
           if (error) {
             const message = `error: '${error}' stdout = '${stdout}' stderr = '${stderr}'`;
             reject(message);
@@ -217,6 +217,15 @@ export class Docker {
           //doesn't work otherwise for 'build - t nginximg1 .'
           resolve({ result: stdout});
         });
+
+        childProcess.stdout.on("data", (chunk) => {
+          process.stdout.write( chunk.toString() );
+        });
+
+        childProcess.stderr.on("data", (chunk) => {
+          process.stderr.write( chunk.toString() );
+        });
+
       });
     }).then(function(data: any) {
       //console.log('data:', data);


### PR DESCRIPTION
For long running docker commands,
it is quite convinient to stream stdout and stderr
from the child process to the host process.
Otherwise you are only able get and display the result of the stream,
after docker.command was executed.