### PR TITLE
Establish compatibility with newer versions of Docker

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -176,7 +176,7 @@ export const dockerCommand = async (
     echo: true,
     env: undefined,
     machineName: undefined,
-    stdin: undefined
+    stdin: undefined,
   },
 ) => {
   let machineconfig = "";
@@ -246,7 +246,7 @@ export class Docker {
       echo: true,
       env: undefined,
       machineName: undefined,
-      stdin: undefined
+      stdin: undefined,
     },
   ) {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,6 +194,7 @@ export const dockerCommand = async (
       DEBUG: "",
       HOME: process.env.HOME,
       PATH: process.env.PATH,
+      USER: process.env.USER,
       ...options.env,
     },
     maxBuffer: 200 * 1024 * 1024,


### PR DESCRIPTION
Recent versions of Docker require the USER env variable to be set. This PR exposes the USER env variable to the docker cli when executing a command.