### PR TITLE
add prepare script to allow installation from github

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "tslint --project .",
     "lintfix": "tslint --project . --fix",
     "build": "rimraf dist/ && tsc",
+    "prepare": "npm run build",
     "test-spec": "ts-node node_modules/blue-tape/bin/blue-tape.js \"src/**/*.spec.ts\" | tap-diff",
     "test": "npm run lint && npm run build && npm run test-spec",
     "prepublish": "npm run lint && npm run build && rimraf \"dist/**/*.spec.*\""


### PR DESCRIPTION
This PR adds a `prepare` script. This is very useful because it lets you install the package directly from github using `npm install <github-url>`. If this is missing, the installation fails because the dist folder is empty (because the project needs to be built).